### PR TITLE
enhance country selection dialog with customizable title and icons

### DIFF
--- a/app/src/main/java/com/joelkanyi/jcomposecountrycodepicker/MainActivity.kt
+++ b/app/src/main/java/com/joelkanyi/jcomposecountrycodepicker/MainActivity.kt
@@ -119,8 +119,7 @@ private fun PickerContent() {
                         focusedContainerColor = Color.Transparent,
                     ),
                     state = state,
-                    countrySelectionDialogContainerColor = MaterialTheme.colorScheme.background,
-                    countrySelectionDialogContentColor = MaterialTheme.colorScheme.onBackground,
+
                     interactionSource = remember { MutableInteractionSource() }.also { interactionSource ->
                         LaunchedEffect(interactionSource) {
                             interactionSource.interactions.collect {
@@ -136,6 +135,30 @@ private fun PickerContent() {
                     keyboardOptions = KeyboardOptions.Default.copy(
                         imeAction = ImeAction.Next,
                     ),
+//                    countrySelectionDialogContainerColor = MaterialTheme.colorScheme.background,
+//                    countrySelectionDialogContentColor = MaterialTheme.colorScheme.onBackground,
+//                    countrySelectionDialogTitle = {
+//                        Text(
+//                            text = "Select Joel",
+//                            style = MaterialTheme.typography.titleMedium.copy(
+//                                fontWeight = FontWeight.Bold,
+//                            ),
+//                        )
+//                    },
+//                    countrySelectionDialogSearchIcon = {
+//                        Icon(
+//                            imageVector = Icons.Default.Send,
+//                            contentDescription = "Search",
+//                            tint = MaterialTheme.colorScheme.onBackground,
+//                        )
+//                    },
+//                    countrySelectionDialogBackIcon = {
+//                        Icon(
+//                            imageVector = Icons.Default.Close,
+//                            contentDescription = "Back",
+//                            tint = MaterialTheme.colorScheme.onBackground,
+//                        )
+//                    },
                 )
             }
 

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -68,6 +68,9 @@ Use the state you defined (`val state = rememberKomposeCountryCodePickerState()`
 | **state**                                | The state of the country code picker.                                                      |
 | **countrySelectionDialogContainerColor** | The color of the country selection dialog container.                                       |
 | **countrySelectionDialogContentColor**   | The color of the country selection dialog content.                                         |
+| **countrySelectionDialogTitle**   | The title of the country selection dialog.                                         |
+| **countrySelectionDialogSearchIcon**   | The icon to be used for the search field in the country selection dialog. |
+| **countrySelectionDialogBackIcon**   | The icon to be used for the back button in the country selection dialog. |
 | **textStyle**                            | The style to be used for displaying text on the `TextField` and the selected country.       |
 | **interactionSource**                    | The `MutableInteractionSource` representing the stream of Interactions for this text field. |
 | **selectedCountryFlagSize**              | The size of the selected country flag (width and height in `.dp`).                         |

--- a/komposecountrycodepicker/api/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/komposecountrycodepicker.api
@@ -4,13 +4,14 @@ public abstract interface annotation class com/joelkanyi/jcomposecountrycodepick
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$CountrySelectionDialogKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$CountrySelectionDialogKt;
 	public fun <init> ()V
-	public final fun getLambda$317520286$komposecountrycodepicker_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1310763941$komposecountrycodepicker_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt;
 	public fun <init> ()V
 	public final fun getLambda$-449382675$komposecountrycodepicker_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-907732374$komposecountrycodepicker_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface class com/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker {
@@ -37,7 +38,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountryCode
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialogKt {
-	public static final fun CountrySelectionDialog-K2djEUw (Ljava/util/List;JJLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/window/DialogProperties;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CountrySelectionDialog-OWbAXeM (Ljava/util/List;JJLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/window/DialogProperties;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerDefaults {
@@ -47,6 +48,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCoun
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
+	public static final fun KomposeCountryCodePicker-4lQVm7s (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
 	public static final fun KomposeCountryCodePicker-8MMxfyk (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;III)V
 	public static final fun qaAutomationTestTag (Landroidx/compose/ui/Modifier;Ljava/lang/String;)Landroidx/compose/ui/Modifier;
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
@@ -74,6 +74,9 @@ import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.searchForAnItem
  * @param onSelect Called when a country is selected.
  * @param modifier Modifier to be applied to the layout.
  * @param properties The properties of the dialog.
+ * @param title A composable function to display the title of the dialog.
+ * @param backIcon A composable function to display the back icon in the top app bar.
+ * @param searchIcon A composable function to display the search icon in the top app bar.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,6 +93,30 @@ public fun CountrySelectionDialog(
             dismissOnClickOutside = it.dismissOnClickOutside,
             securePolicy = it.securePolicy,
             usePlatformDefaultWidth = false,
+        )
+    },
+    title: @Composable () -> Unit = {
+        Text(
+            modifier = Modifier
+                .offset(y = (-2).dp)
+                .qaAutomationTestTag("countryDialogTitle"),
+            text = stringResource(id = R.string.select_country),
+            style = MaterialTheme.typography.titleMedium,
+            color = contentColor,
+        )
+    },
+    backIcon: @Composable () -> Unit = {
+        Icon(
+            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+            contentDescription = null,
+            tint = contentColor,
+        )
+    },
+    searchIcon: @Composable () -> Unit = {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            tint = contentColor,
         )
     },
 ) {
@@ -128,7 +155,8 @@ public fun CountrySelectionDialog(
                                     value = searchValue,
                                     onValueChange = { searchStr ->
                                         searchValue = searchStr
-                                        filteredItems = countryList.searchForAnItem(searchStr, context)
+                                        filteredItems =
+                                            countryList.searchForAnItem(searchStr, context)
                                     },
                                     placeholder = {
                                         Text(
@@ -154,14 +182,7 @@ public fun CountrySelectionDialog(
                                     ),
                                 )
                             } else {
-                                Text(
-                                    modifier = Modifier
-                                        .offset(y = (-2).dp)
-                                        .qaAutomationTestTag("countryDialogTitle"),
-                                    text = stringResource(id = R.string.select_country),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = contentColor,
-                                )
+                                title()
                             }
                         },
                         navigationIcon = {
@@ -172,11 +193,7 @@ public fun CountrySelectionDialog(
                                     onDismissRequest()
                                 },
                             ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                                    contentDescription = null,
-                                    tint = contentColor,
-                                )
+                                backIcon()
                             }
                         },
                         actions = {
@@ -187,11 +204,7 @@ public fun CountrySelectionDialog(
                                     isSearch = !isSearch
                                 },
                             ) {
-                                Icon(
-                                    imageVector = Icons.Default.Search,
-                                    contentDescription = null,
-                                    tint = contentColor,
-                                )
+                                searchIcon()
                             }
                         },
                         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -23,12 +23,15 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -63,6 +66,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.joelkanyi.jcomposecountrycodepicker.R
 import com.joelkanyi.jcomposecountrycodepicker.annotation.RestrictedApi
 import com.joelkanyi.jcomposecountrycodepicker.data.Country
 import com.joelkanyi.jcomposecountrycodepicker.data.FlagSize
@@ -405,6 +409,189 @@ public fun KomposeCountryCodePicker(
             },
             containerColor = countrySelectionDialogContainerColor,
             contentColor = countrySelectionDialogContentColor,
+        )
+    }
+
+    /**
+     * if [showOnlyCountryCodePicker] is true, only the country code picker
+     * will be displayed.
+     */
+    if (showOnlyCountryCodePicker) {
+        SelectedCountryComponent(
+            modifier = modifier,
+            selectedCountry = state.countryCode.getCountry(),
+            showCountryCode = state.showCountryCode,
+            showFlag = state.showCountryFlag,
+            onClickSelectedCountry = {
+                if (enabled) {
+                    openCountrySelectionDialog = true
+                }
+            },
+            selectedCountryFlagSize = selectedCountryFlagSize,
+            textStyle = textStyle,
+        )
+    } else {
+        OutlinedTextField(
+            modifier = modifier
+                .qaAutomationTestTag("countryCodePickerTextField"),
+            shape = shape,
+            value = phoneNo,
+            onValueChange = {
+                if (text != it && showOnlyCountryCodePicker.not()) {
+                    onValueChange(it)
+                }
+            },
+            placeholder = {
+                placeholder(state.countryCode)
+            },
+            singleLine = true,
+            colors = colors,
+            isError = error,
+            visualTransformation = PhoneNumberTransformation(
+                state.countryCode.uppercase(),
+            ),
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            leadingIcon = {
+                SelectedCountryComponent(
+                    selectedCountry = state.countryCode.getCountry(),
+                    showCountryCode = state.showCountryCode,
+                    showFlag = state.showCountryFlag,
+                    onClickSelectedCountry = {
+                        if (enabled) {
+                            openCountrySelectionDialog = true
+                        }
+                    },
+                    selectedCountryFlagSize = selectedCountryFlagSize,
+                    textStyle = textStyle,
+                )
+            },
+            trailingIcon = trailingIcon,
+            interactionSource = interactionSource,
+            textStyle = textStyle,
+            enabled = enabled,
+        )
+    }
+}
+
+/**
+ * [KomposeCountryCodePicker] is a composable that displays a text field
+ * with a country code picker dialog.
+ *
+ * @param state The state of the country code picker.
+ * @param text The text to be displayed in the text field.
+ * @param modifier Modifier to be applied to the layout.
+ * @param onValueChange Called when the value is changed.
+ * @param error If true, the text field will be displayed in the error
+ *    state.
+ * @param showOnlyCountryCodePicker If true, only the country code picker
+ *    will be displayed.
+ * @param shape The shape of the text field's outline.
+ * @param placeholder The placeholder to be displayed in the text field.
+ * @param colors The colors to be used to display the text field.
+ * @param trailingIcon The trailing icon to be displayed in the text field.
+ * @param countrySelectionDialogContainerColor The color to be used to
+ *    display the country selection dialog container.
+ * @param countrySelectionDialogContentColor The color to be used to
+ *    display the country selection dialog content. text.
+ *  @param countrySelectionDialogTitle The title to be displayed in the
+ *    country selection dialog.
+ *  @param countrySelectionDialogBackIcon The back icon to be displayed in
+ *  country selection dialog.
+ *  @param countrySelectionDialogSearchIcon The search icon to be displayed
+ *  in country selection dialog.
+ * @param interactionSource The MutableInteractionSource representing the
+ *    stream of Interactions for this text field.
+ * @param selectedCountryFlagSize The size of the selected country flag
+ *    (width and height in `.dp`).
+ * @param textStyle The style to be used for displaying text on the
+ *    `TextField` and the selected country.
+ * @param enabled Controls the enabled state of the text field.
+ * @param keyboardOptions The keyboard options to be used to display the
+ *   keyboard.
+ * @param keyboardActions The keyboard actions to be used to display
+ *   the keyboard.
+ */
+@OptIn(RestrictedApi::class)
+@Composable
+public fun KomposeCountryCodePicker(
+    state: CountryCodePicker,
+    text: String,
+    modifier: Modifier = Modifier,
+    onValueChange: (String) -> Unit = {},
+    error: Boolean = false,
+    showOnlyCountryCodePicker: Boolean = false,
+    shape: Shape = MaterialTheme.shapes.medium,
+    placeholder: @Composable ((defaultLang: String) -> Unit) = { defaultLang ->
+        DefaultPlaceholder(defaultLang)
+    },
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+    trailingIcon: @Composable (() -> Unit)? = null,
+    countrySelectionDialogContainerColor: Color = MaterialTheme.colorScheme.background,
+    countrySelectionDialogContentColor: Color = MaterialTheme.colorScheme.onBackground,
+    countrySelectionDialogTitle: @Composable () -> Unit = {
+        Text(
+            modifier = Modifier
+                .offset(y = (-2).dp)
+                .qaAutomationTestTag("countryDialogTitle"),
+            text = stringResource(id = R.string.select_country),
+            style = MaterialTheme.typography.titleMedium,
+            color = countrySelectionDialogContentColor,
+        )
+    },
+    countrySelectionDialogBackIcon: @Composable () -> Unit = {
+        Icon(
+            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+            contentDescription = null,
+            tint = countrySelectionDialogContentColor,
+        )
+    },
+    countrySelectionDialogSearchIcon: @Composable () -> Unit = {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            tint = countrySelectionDialogContentColor,
+        )
+    },
+    interactionSource: MutableInteractionSource = MutableInteractionSource(),
+    selectedCountryFlagSize: FlagSize = FlagSize(28.dp, 18.dp),
+    textStyle: TextStyle = LocalTextStyle.current,
+    enabled: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default.copy(
+        keyboardType = KeyboardType.Phone,
+        imeAction = ImeAction.Next,
+    ),
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    var openCountrySelectionDialog by rememberSaveable { mutableStateOf(false) }
+
+    val phoneTextPair = extractCountryCodeAndPhoneNumber(text)
+    val countryCode = phoneTextPair.first
+    val phoneNo = phoneTextPair.second
+
+    LaunchedEffect(countryCode) {
+        countryCode?.let { state.setCode(it) }
+    }
+
+    LaunchedEffect(phoneNo) {
+        state.setPhoneNo(phoneNo)
+    }
+
+    if (openCountrySelectionDialog) {
+        CountrySelectionDialog(
+            countryList = state.countryList,
+            onDismissRequest = {
+                openCountrySelectionDialog = false
+            },
+            onSelect = { countryItem ->
+                state.setCode(countryItem.code)
+                openCountrySelectionDialog = false
+            },
+            containerColor = countrySelectionDialogContainerColor,
+            contentColor = countrySelectionDialogContentColor,
+            title = countrySelectionDialogTitle,
+            backIcon = countrySelectionDialogBackIcon,
+            searchIcon = countrySelectionDialogSearchIcon,
         )
     }
 


### PR DESCRIPTION
Fixes #139 

You can customize the container and content colors of the dialog, as well as provide your own title, back, and search icon composables:
```kotlin
KomposeCountryCodePicker(
    ...
    countrySelectionDialogContainerColor = MaterialTheme.colorScheme.background,
    countrySelectionDialogContentColor = MaterialTheme.colorScheme.onBackground,
    countrySelectionDialogTitle = {
        Text(
            text = "Select Joel",
            style = MaterialTheme.typography.titleMedium.copy(
                fontWeight = FontWeight.Bold,
            ),
        )
    },
    countrySelectionDialogSearchIcon = {
        Icon(
            imageVector = Icons.Default.Send,
            contentDescription = "Search",
            tint = MaterialTheme.colorScheme.onBackground,
        )
    },
    countrySelectionDialogBackIcon = {
        Icon(
            imageVector = Icons.Default.Close,
            contentDescription = "Back",
            tint = MaterialTheme.colorScheme.onBackground,
        )
    },
)
```