### PR TITLE
fix: Restore country name localization in dialog

### DIFF
--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
@@ -73,6 +73,7 @@ import com.joelkanyi.jcomposecountrycodepicker.resources.ic_arrow_back
 import com.joelkanyi.jcomposecountrycodepicker.resources.ic_search
 import com.joelkanyi.jcomposecountrycodepicker.resources.search_country
 import com.joelkanyi.jcomposecountrycodepicker.resources.select_country
+import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.getCountryName
 import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.searchForAnItem
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -348,7 +349,7 @@ public fun CountrySelectionDialog(
                                         modifier = Modifier
                                             .weight(1f)
                                             .qaAutomationTestTag("countryName"),
-                                        text = countryItem.name,
+                                        text = stringResource(getCountryName(countryItem.code.lowercase())),
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = contentColor,
                                     )

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -73,9 +74,10 @@ import com.joelkanyi.jcomposecountrycodepicker.resources.ic_arrow_back
 import com.joelkanyi.jcomposecountrycodepicker.resources.ic_search
 import com.joelkanyi.jcomposecountrycodepicker.resources.search_country
 import com.joelkanyi.jcomposecountrycodepicker.resources.select_country
+import com.joelkanyi.jcomposecountrycodepicker.utils.buildCountrySearchIndex
 import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.getCountryName
-import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.searchForAnItem
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -148,6 +150,17 @@ public fun CountrySelectionDialog(
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
     val listFocusRequester = remember { FocusRequester() }
+    val localizedCountryNamesByCode by produceState(
+        initialValue = emptyMap(),
+        key1 = countryList,
+    ) {
+        value = countryList.associate { country ->
+            country.code.lowercase() to getString(getCountryName(country.code.lowercase()))
+        }
+    }
+    val countrySearchIndex = remember(countryList, localizedCountryNamesByCode) {
+        countryList.buildCountrySearchIndex(localizedCountryNamesByCode)
+    }
 
     val countriesData = if (searchValue.isEmpty()) countryList else filteredItems
 
@@ -204,8 +217,7 @@ public fun CountrySelectionDialog(
                                         value = searchValue,
                                         onValueChange = { searchStr ->
                                             searchValue = searchStr
-                                            filteredItems =
-                                                countryList.searchForAnItem(searchStr)
+                                            filteredItems = countrySearchIndex.search(searchStr)
                                         },
                                         placeholder = {
                                             Text(

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
@@ -74,8 +74,8 @@ import com.joelkanyi.jcomposecountrycodepicker.resources.ic_arrow_back
 import com.joelkanyi.jcomposecountrycodepicker.resources.ic_search
 import com.joelkanyi.jcomposecountrycodepicker.resources.search_country
 import com.joelkanyi.jcomposecountrycodepicker.resources.select_country
-import com.joelkanyi.jcomposecountrycodepicker.utils.buildCountrySearchIndex
 import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.getCountryName
+import com.joelkanyi.jcomposecountrycodepicker.utils.buildCountrySearchIndex
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.painterResource

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearch.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearch.kt
@@ -64,5 +64,4 @@ internal fun List<Country>.buildCountrySearchIndex(
     return CountrySearchIndex(searchableCountries)
 }
 
-internal fun List<Country>.searchCountries(searchStr: String): List<Country> =
-    buildCountrySearchIndex().search(searchStr)
+internal fun List<Country>.searchCountries(searchStr: String): List<Country> = buildCountrySearchIndex().search(searchStr)

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearch.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearch.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joelkanyi.jcomposecountrycodepicker.utils
+
+import com.joelkanyi.jcomposecountrycodepicker.data.Country
+
+internal class SearchableCountry(
+    val country: Country,
+    val originalNameNormalized: String,
+    val localizedNameNormalized: String?,
+)
+
+internal class CountrySearchIndex internal constructor(
+    private val entries: List<SearchableCountry>,
+) {
+    fun search(searchStr: String): List<Country> {
+        val normalizedSearch = searchStr.unaccent()
+        if (normalizedSearch.isEmpty()) return entries.map { it.country }
+
+        return entries.filter { searchableCountry ->
+            searchableCountry.localizedNameNormalized?.contains(
+                normalizedSearch,
+                ignoreCase = true,
+            ) == true ||
+                searchableCountry.originalNameNormalized.contains(
+                    normalizedSearch,
+                    ignoreCase = true,
+                ) ||
+                searchableCountry.country.phoneNoCode.contains(
+                    normalizedSearch,
+                    ignoreCase = true,
+                ) ||
+                searchableCountry.country.code.contains(
+                    normalizedSearch,
+                    ignoreCase = true,
+                )
+        }.map { it.country }
+    }
+}
+
+internal fun List<Country>.buildCountrySearchIndex(
+    localizedNamesByCode: Map<String, String> = emptyMap(),
+): CountrySearchIndex {
+    val searchableCountries = map { country ->
+        SearchableCountry(
+            country = country,
+            originalNameNormalized = country.name.unaccent(),
+            localizedNameNormalized = localizedNamesByCode[country.code.lowercase()]?.unaccent(),
+        )
+    }
+    return CountrySearchIndex(searchableCountries)
+}
+
+internal fun List<Country>.searchCountries(searchStr: String): List<Country> =
+    buildCountrySearchIndex().search(searchStr)

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
@@ -99,31 +99,6 @@ internal object PickerUtils {
     fun String.removeSpecialCharacters(): String = this.replace("[^a-zA-Z0-9]".toRegex(), "")
 
     /**
-     * [searchForAnItem] Returns a list of items that match the search string.
-     *
-     * @param searchStr The search string.
-     */
-    fun List<Country>.searchForAnItem(
-        searchStr: String,
-    ): List<Country> {
-        val filteredItems = filter {
-            it.name.unaccent().contains(
-                searchStr,
-                ignoreCase = true,
-            ) ||
-                it.phoneNoCode.contains(
-                    searchStr,
-                    ignoreCase = true,
-                ) ||
-                it.code.contains(
-                    searchStr,
-                    ignoreCase = true,
-                )
-        }
-        return filteredItems.toList()
-    }
-
-    /**
      * Map of shared phone codes to their preferred/primary country code.
      * When multiple countries share the same dialling code, this map determines
      * which country is returned by [extractCountryCodeAndPhoneNumber].

--- a/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
+++ b/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joelkanyi.jcomposecountrycodepicker.utils
+
+import com.joelkanyi.jcomposecountrycodepicker.data.Country
+import com.joelkanyi.jcomposecountrycodepicker.resources.Res
+import com.joelkanyi.jcomposecountrycodepicker.resources.ke
+import com.joelkanyi.jcomposecountrycodepicker.resources.ug
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CountrySearchTest {
+
+    @Test
+    fun searchByCountryName() {
+        val testData = listOf(
+            Country("ke", "+254", "Kenya", Res.drawable.ke),
+            Country("ug", "+256", "Uganda", Res.drawable.ug),
+        )
+        val expected = listOf(Country("ke", "+254", "Kenya", Res.drawable.ke))
+        val result = testData.searchCountries("kEnYa")
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun searchByPhoneCode() {
+        val countries = PickerUtils.allCountries
+        val results = countries.searchCountries("+254")
+        assertTrue(results.any { it.code == "ke" }, "Search by +254 should find Kenya")
+    }
+
+    @Test
+    fun searchByCountryCode() {
+        val countries = PickerUtils.allCountries
+        val results = countries.searchCountries("ke")
+        assertTrue(results.any { it.code == "ke" }, "Search by 'ke' should find Kenya")
+    }
+
+    @Test
+    fun searchReturnsEmptyForNonexistentQuery() {
+        val countries = PickerUtils.allCountries
+        val results = countries.searchCountries("zzzzzzzzzzz")
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun searchIsCaseInsensitive() {
+        val countries = PickerUtils.allCountries
+        val lower = countries.searchCountries("kenya")
+        val upper = countries.searchCountries("KENYA")
+        assertEquals(lower.size, upper.size)
+    }
+}

--- a/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
+++ b/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
@@ -37,6 +37,21 @@ class CountrySearchTest {
     }
 
     @Test
+    fun searchByLocalizedCountryName() {
+        val testData = listOf(
+            Country("ke", "+254", "Kenya", Res.drawable.ke),
+            Country("ug", "+256", "Uganda", Res.drawable.ug),
+        )
+        val localizedNamesByCode = mapOf("ke" to "Kenia")
+        val searchIndex = testData.buildCountrySearchIndex(localizedNamesByCode = localizedNamesByCode)
+
+        val expected = listOf(Country("ke", "+254", "Kenya", Res.drawable.ke))
+        val result = testData.searchCountries("kenia", searchIndex = searchIndex)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun searchByPhoneCode() {
         val countries = PickerUtils.allCountries
         val results = countries.searchCountries("+254")

--- a/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
+++ b/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/CountrySearchTest.kt
@@ -46,7 +46,7 @@ class CountrySearchTest {
         val searchIndex = testData.buildCountrySearchIndex(localizedNamesByCode = localizedNamesByCode)
 
         val expected = listOf(Country("ke", "+254", "Kenya", Res.drawable.ke))
-        val result = testData.searchCountries("kenia", searchIndex = searchIndex)
+        val result = searchIndex.search("kenia")
 
         assertEquals(expected, result)
     }

--- a/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtilsTest.kt
+++ b/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtilsTest.kt
@@ -21,7 +21,6 @@ import com.joelkanyi.jcomposecountrycodepicker.resources.ke
 import com.joelkanyi.jcomposecountrycodepicker.resources.ug
 import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.getCountry
 import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.removeSpecialCharacters
-import com.joelkanyi.jcomposecountrycodepicker.utils.PickerUtils.searchForAnItem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -59,17 +58,6 @@ class PickerUtilsTest {
         val testData = "+-,`˜@/.!#%^&*()254712345678_+$"
         val result = testData.removeSpecialCharacters()
         assertEquals("254712345678", result)
-    }
-
-    @Test
-    fun testSearchForAnItem() {
-        val testData = listOf(
-            Country("ke", "+254", "Kenya", Res.drawable.ke),
-            Country("ug", "+256", "Uganda", Res.drawable.ug),
-        )
-        val correctResult = listOf(Country("ke", "+254", "Kenya", Res.drawable.ke))
-        val result = testData.searchForAnItem("kEnYa")
-        assertEquals(correctResult, result)
     }
 
     @Test
@@ -153,35 +141,6 @@ class PickerUtilsTest {
         val (code, phone) = PickerUtils.extractCountryCodeAndPhoneNumber("")
         assertNull(code)
         assertEquals("", phone)
-    }
-
-    @Test
-    fun searchByPhoneCode() {
-        val countries = PickerUtils.allCountries
-        val results = countries.searchForAnItem("+254")
-        assertTrue(results.any { it.code == "ke" }, "Search by +254 should find Kenya")
-    }
-
-    @Test
-    fun searchByCountryCode() {
-        val countries = PickerUtils.allCountries
-        val results = countries.searchForAnItem("ke")
-        assertTrue(results.any { it.code == "ke" }, "Search by 'ke' should find Kenya")
-    }
-
-    @Test
-    fun searchReturnsEmptyForNonexistentQuery() {
-        val countries = PickerUtils.allCountries
-        val results = countries.searchForAnItem("zzzzzzzzzzz")
-        assertTrue(results.isEmpty())
-    }
-
-    @Test
-    fun searchIsCaseInsensitive() {
-        val countries = PickerUtils.allCountries
-        val lower = countries.searchForAnItem("kenya")
-        val upper = countries.searchForAnItem("KENYA")
-        assertEquals(lower.size, upper.size)
     }
 
     @Test


### PR DESCRIPTION
In addition to restoring the display of the localized name, this PR proposes a new approach to country name search to support searching both the default and localized names within the constraints of Compose Multiplatform.