### PR TITLE
feat: add customizable `dropDownIcon` to `KomposeCountryCodePicker`

### DIFF
--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -61,6 +61,7 @@ The country selection dialog can be customized through additional parameters on 
 | `countrySelectionDialogTitle` | `@Composable () -> Unit` | "Select Country" | A composable for the dialog title. |
 | `countrySelectionDialogBackIcon` | `@Composable () -> Unit` | Back arrow icon | A composable for the back/dismiss button icon. |
 | `countrySelectionDialogSearchIcon` | `@Composable () -> Unit` | Search icon | A composable for the search toggle icon. |
+| `dropDownIcon` | `@Composable () -> Unit` | Down arrow icon | A composable for the dropdown indicator next to the selected country. Tinted by `LocalContentColor` by default. |
 
 The dialog is **responsive**: it displays full-screen on compact screens (width < 600dp) and as a popup on larger screens.
 

--- a/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
@@ -4,7 +4,8 @@ public abstract interface annotation class com/joelkanyi/jcomposecountrycodepick
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt;
 	public fun <init> ()V
-	public final fun getLambda$-907732374$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1604413287$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$724952553$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface class com/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker {
@@ -35,7 +36,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySele
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
-	public static final fun KomposeCountryCodePicker-4lQVm7s (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun KomposeCountryCodePicker-TVnyiQU (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }
 

--- a/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_arrow_back.xml
+++ b/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_arrow_back.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
 
-    <path android:fillColor="#e3e3e3" android:pathData="m313,520 l224,224 -57,56 -320,-320 320,-320 57,56 -224,224h487v80L313,520Z"/>
+    <path android:fillColor="#000000" android:pathData="m313,520 l224,224 -57,56 -320,-320 320,-320 57,56 -224,224h487v80L313,520Z"/>
 
 </vector>

--- a/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_arrow_drop_down.xml
+++ b/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_arrow_drop_down.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
 
-    <path android:fillColor="#e3e3e3" android:pathData="M480,600 L280,400h400L480,600Z"/>
+    <path android:fillColor="#000000" android:pathData="M480,600 L280,400h400L480,600Z"/>
 
 </vector>

--- a/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_search.xml
+++ b/komposecountrycodepicker/src/commonMain/composeResources/drawable/ic_search.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
 
-    <path android:fillColor="#e3e3e3" android:pathData="M784,840 L532,588q-30,24 -69,38t-83,14q-109,0 -184.5,-75.5T120,380q0,-109 75.5,-184.5T380,120q109,0 184.5,75.5T640,380q0,44 -14,83t-38,69l252,252 -56,56ZM380,560q75,0 127.5,-52.5T560,380q0,-75 -52.5,-127.5T380,200q-75,0 -127.5,52.5T200,380q0,75 52.5,127.5T380,560Z"/>
+    <path android:fillColor="#000000" android:pathData="M784,840 L532,588q-30,24 -69,38t-83,14q-109,0 -184.5,-75.5T120,380q0,-109 75.5,-184.5T380,120q109,0 184.5,75.5T640,380q0,44 -14,83t-38,69l252,252 -56,56ZM380,560q75,0 127.5,-52.5T560,380q0,-75 -52.5,-127.5T380,200q-75,0 -127.5,52.5T200,380q0,75 52.5,127.5T380,560Z"/>
 
 </vector>

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -350,6 +350,9 @@ public fun rememberKomposeCountryCodePickerState(
  *    the back icon in the country selection dialog.
  * @param countrySelectionDialogSearchIcon A composable lambda to display
  *    the search icon in the country selection dialog.
+ * @param dropDownIcon A composable lambda to display the dropdown icon
+ *    next to the selected country. Defaults to a down arrow icon tinted
+ *    with [LocalContentColor].
  * @param interactionSource The [MutableInteractionSource] representing the
  *    stream of Interactions for this text field.
  * @param selectedCountryFlagSize The size of the selected country flag
@@ -401,6 +404,12 @@ public fun KomposeCountryCodePicker(
             painter = painterResource(Res.drawable.ic_search),
             contentDescription = "Search",
             tint = countrySelectionDialogContentColor,
+        )
+    },
+    dropDownIcon: @Composable () -> Unit = {
+        Icon(
+            painter = painterResource(Res.drawable.ic_arrow_drop_down),
+            contentDescription = "Select country",
         )
     },
     interactionSource: MutableInteractionSource = MutableInteractionSource(),
@@ -458,6 +467,7 @@ public fun KomposeCountryCodePicker(
             },
             selectedCountryFlagSize = selectedCountryFlagSize,
             textStyle = textStyle,
+            dropDownIcon = dropDownIcon,
         )
     } else {
         OutlinedTextField(
@@ -493,6 +503,7 @@ public fun KomposeCountryCodePicker(
                     },
                     selectedCountryFlagSize = selectedCountryFlagSize,
                     textStyle = textStyle,
+                    dropDownIcon = dropDownIcon,
                 )
             },
             trailingIcon = trailingIcon,
@@ -538,6 +549,7 @@ private fun DefaultPlaceholder(
  * @param showCountryCode If true, the country code will be shown.
  * @param showFlag] If true, the country flag will be shown.
  * @param showCountryName If true, the country name will be shown.
+ * @param dropDownIcon A composable lambda to display the dropdown icon.
  */
 @Composable
 private fun SelectedCountryComponent(
@@ -545,6 +557,7 @@ private fun SelectedCountryComponent(
     selectedCountryFlagSize: FlagSize,
     textStyle: TextStyle,
     onClickSelectedCountry: () -> Unit,
+    dropDownIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     selectedCountryPadding: Dp = 8.dp,
     showCountryCode: Boolean = true,
@@ -594,11 +607,7 @@ private fun SelectedCountryComponent(
                 style = textStyle,
             )
         }
-        Icon(
-            painter = painterResource(Res.drawable.ic_arrow_drop_down),
-            contentDescription = "Select country",
-            modifier = Modifier.qaAutomationTestTag("countryDropDown"),
-        )
+        dropDownIcon()
     }
 }
 


### PR DESCRIPTION
This commit introduces a new customization option for the country code picker and updates default icon colors.

Changes:
- Added `dropDownIcon` parameter to `KomposeCountryCodePicker` and `SelectedCountryComponent` to allow custom dropdown indicators.
- Updated default vector icons (`ic_arrow_back`, `ic_arrow_drop_down`, `ic_search`) by changing their `fillColor` from `#e3e3e3` to `#000000`.
- Documented the new `dropDownIcon` property in `docs/customizations.md`.
- Updated public API signatures to reflect the new parameter.

This fixes #239 