### PR TITLE
feat: add `leadingIconContainerColor` customization

### DIFF
--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -43,6 +43,7 @@ The `KomposeCountryCodePicker` composable accepts the following parameters:
 | `placeholder` | `@Composable (String) -> Unit` | Default hint | A composable to display as the placeholder. Receives the current country code. |
 | `colors` | `TextFieldColors` | `TextFieldDefaults.colors()` | Colors for the text field. |
 | `trailingIcon` | `@Composable (() -> Unit)?` | `null` | An optional trailing icon composable. |
+| `leadingIconContainerColor` | `Color` | `Color.Unspecified` | Background color of the country selector area. When `Color.Unspecified`, no background is drawn. |
 | `interactionSource` | `MutableInteractionSource` | `MutableInteractionSource()` | The interaction source for the text field. |
 | `selectedCountryFlagSize` | `FlagSize` | `FlagSize(28.dp, 18.dp)` | The width and height of the selected country flag. |
 | `textStyle` | `TextStyle` | `LocalTextStyle.current` | The text style for the text field and selected country display. |

--- a/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
@@ -37,6 +37,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySele
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
 	public static final fun KomposeCountryCodePicker-3lkZ96c (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun SelectedCountryComponent-VG7Fs9s (Lcom/joelkanyi/jcomposecountrycodepicker/data/Country;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;FZZZJLandroidx/compose/runtime/Composer;III)V
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }
 

--- a/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
@@ -4,8 +4,8 @@ public abstract interface annotation class com/joelkanyi/jcomposecountrycodepick
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt;
 	public fun <init> ()V
-	public final fun getLambda$1604413287$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$724952553$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-797883394$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-887531264$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface class com/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker {
@@ -36,7 +36,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySele
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
-	public static final fun KomposeCountryCodePicker-TVnyiQU (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun KomposeCountryCodePicker-3lkZ96c (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }
 

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -16,6 +16,7 @@
 package com.joelkanyi.jcomposecountrycodepicker.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +38,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
@@ -45,8 +47,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextStyle
@@ -353,6 +360,9 @@ public fun rememberKomposeCountryCodePickerState(
  * @param dropDownIcon A composable lambda to display the dropdown icon
  *    next to the selected country. Defaults to a down arrow icon tinted
  *    with [LocalContentColor].
+ * @param leadingIconContainerColor The background color of the country
+ *    selector area. When [Color.Unspecified] (the default), no background
+ *    is drawn.
  * @param interactionSource The [MutableInteractionSource] representing the
  *    stream of Interactions for this text field.
  * @param selectedCountryFlagSize The size of the selected country flag
@@ -412,6 +422,7 @@ public fun KomposeCountryCodePicker(
             contentDescription = "Select country",
         )
     },
+    leadingIconContainerColor: Color = Color.Unspecified,
     interactionSource: MutableInteractionSource = MutableInteractionSource(),
     selectedCountryFlagSize: FlagSize = FlagSize(28.dp, 18.dp),
     textStyle: TextStyle = LocalTextStyle.current,
@@ -468,11 +479,45 @@ public fun KomposeCountryCodePicker(
             selectedCountryFlagSize = selectedCountryFlagSize,
             textStyle = textStyle,
             dropDownIcon = dropDownIcon,
+            containerColor = leadingIconContainerColor,
         )
     } else {
+        val hasContainerColor = leadingIconContainerColor != Color.Unspecified
+        var leadingIconCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+        var leadingIconEndX by remember { mutableFloatStateOf(0f) }
+
         OutlinedTextField(
             modifier = modifier
-                .qaAutomationTestTag("countryCodePickerTextField"),
+                .qaAutomationTestTag("countryCodePickerTextField")
+                .then(
+                    if (hasContainerColor) {
+                        Modifier
+                            .clip(shape)
+                            .onGloballyPositioned { tfCoords ->
+                                leadingIconCoordinates?.let { iconCoords ->
+                                    if (iconCoords.isAttached) {
+                                        val pos = tfCoords.localPositionOf(
+                                            iconCoords,
+                                            androidx.compose.ui.geometry.Offset.Zero,
+                                        )
+                                        leadingIconEndX =
+                                            pos.x + iconCoords.size.width.toFloat()
+                                    }
+                                }
+                            }
+                            .drawWithContent {
+                                if (leadingIconEndX > 0f) {
+                                    drawRect(
+                                        color = leadingIconContainerColor,
+                                        size = Size(leadingIconEndX, size.height),
+                                    )
+                                }
+                                drawContent()
+                            }
+                    } else {
+                        Modifier
+                    },
+                ),
             shape = shape,
             value = phoneNo,
             onValueChange = {
@@ -493,6 +538,11 @@ public fun KomposeCountryCodePicker(
             keyboardActions = keyboardActions,
             leadingIcon = {
                 SelectedCountryComponent(
+                    modifier = if (hasContainerColor) {
+                        Modifier.onGloballyPositioned { leadingIconCoordinates = it }
+                    } else {
+                        Modifier
+                    },
                     selectedCountry = state.countryCode.getCountry(),
                     showCountryCode = state.showCountryCode,
                     showFlag = state.showCountryFlag,
@@ -550,9 +600,11 @@ private fun DefaultPlaceholder(
  * @param showFlag] If true, the country flag will be shown.
  * @param showCountryName If true, the country name will be shown.
  * @param dropDownIcon A composable lambda to display the dropdown icon.
+ * @param containerColor The background color of the country selector
+ *    area. When [Color.Unspecified], no background is drawn.
  */
 @Composable
-private fun SelectedCountryComponent(
+public fun SelectedCountryComponent(
     selectedCountry: Country,
     selectedCountryFlagSize: FlagSize,
     textStyle: TextStyle,
@@ -563,9 +615,17 @@ private fun SelectedCountryComponent(
     showCountryCode: Boolean = true,
     showFlag: Boolean = true,
     showCountryName: Boolean = false,
+    containerColor: Color = Color.Unspecified,
 ) {
     Row(
         modifier = modifier
+            .then(
+                if (containerColor != Color.Unspecified) {
+                    Modifier.background(containerColor)
+                } else {
+                    Modifier
+                },
+            )
             .padding(selectedCountryPadding)
             .qaAutomationTestTag("selectedCountryComponent")
             .clickable(


### PR DESCRIPTION
Introduces a new `leadingIconContainerColor` parameter to `KomposeCountryCodePicker` to allow customizing the background color of the country selector area.

Changes include:
- Added `leadingIconContainerColor` to `KomposeCountryCodePicker` and `SelectedCountryComponent`.
- Implemented logic to draw the background color in the leading icon area of the `OutlinedTextField` using `onGloballyPositioned` and `drawWithContent`.
- Updated documentation in `docs/customizations.md` to include the new parameter.
- Changed `SelectedCountryComponent` visibility from private to public.

This fixes #240 


<img width="400" alt="leadingIconContainerColor example" src="https://github.com/user-attachments/assets/b7a1c891-57de-44dc-8abe-503bd24aff2d" />