### PR TITLE
add support for custom text fields and `selectedCountry` property - #246

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See the [project's website](https://joelkanyi.github.io/kompose-country-code-pic
 - Built-in phone number validation and formatting
 - Search with accent-normalized matching
 - Responsive dialog - full-screen on mobile, popup on desktop/web
+- Custom text field support - use `CountrySelectionDialog` + `state.selectedCountry` for fully custom layouts
 - 13 language translations
 - Customizable colors, shapes, and icons
 - Keyboard navigation support (Arrow keys, Enter, Escape) on desktop and web
@@ -96,6 +97,59 @@ KomposeCountryCodePicker(
     state = state,
 )
 ```
+
+### Fully Custom Text Field
+
+If you have your own design system and want to use your own text field, use `CountrySelectionDialog` and `state.selectedCountry` directly:
+
+```kotlin
+@OptIn(RestrictedApi::class)
+@Composable
+fun PhoneNumberField() {
+    var phoneNumber by rememberSaveable { mutableStateOf("") }
+    var showCountryPicker by rememberSaveable { mutableStateOf(false) }
+    val state = rememberKomposeCountryCodePickerState()
+
+    if (showCountryPicker) {
+        CountrySelectionDialog(
+            countryList = state.countryList,
+            containerColor = MaterialTheme.colorScheme.background,
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            onDismissRequest = { showCountryPicker = false },
+            onSelect = { country ->
+                state.setCode(country.code)
+                showCountryPicker = false
+            },
+        )
+    }
+
+    OutlinedTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = phoneNumber,
+        onValueChange = { phoneNumber = it },
+        placeholder = { Text("Phone Number") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+        leadingIcon = {
+            Row(
+                modifier = Modifier
+                    .clickable { showCountryPicker = true }
+                    .padding(start = 12.dp, end = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    modifier = Modifier.width(28.dp).height(18.dp),
+                    painter = painterResource(state.selectedCountry.flag),
+                    contentDescription = state.selectedCountry.name,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(text = state.selectedCountry.phoneNoCode)
+            }
+        },
+    )
+}
+```
+
+See the [full documentation](https://joelkanyi.github.io/kompose-country-code-picker/usage/#fully-custom-phone-input) for more details and a `BasicTextField` variant.
 
 ## Preview
 

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -49,6 +49,7 @@ The `KomposeCountryCodePicker` composable accepts the following parameters:
 | `textStyle` | `TextStyle` | `LocalTextStyle.current` | The text style for the text field and selected country display. |
 | `enabled` | `Boolean` | `true` | Whether the text field and country picker are enabled. |
 | `keyboardOptions` | `KeyboardOptions` | Phone / Next | Keyboard options for the text field. Defaults to phone keyboard with `ImeAction.Next`. |
+| `selectedCountryPadding` | `Dp` | `8.dp` | Padding around the selected country component. Useful for removing extra spacing when embedding the picker inside a custom text field's decorator box. |
 | `keyboardActions` | `KeyboardActions` | `KeyboardActions.Default` | Keyboard actions for the text field. |
 
 ## Dialog Customizations
@@ -68,7 +69,9 @@ The dialog is **responsive**: it displays full-screen on compact screens (width 
 
 ## CountrySelectionDialog (Standalone)
 
-The `CountrySelectionDialog` composable is part of the public API and can be used independently if you need full control over when the dialog is shown:
+The `CountrySelectionDialog` composable is part of the public API and can be used independently. This is useful when you have your own text field component and want to use the library only for the searchable country list and flag assets — without the built-in `OutlinedTextField` that `KomposeCountryCodePicker` provides.
+
+When a country is selected, call `state.setCode(country.code)` to update the state, then use `state.selectedCountry` to access the selected country's `flag`, `name`, and `phoneNoCode` in your own layout. See the [Fully Custom Phone Input](usage.md#fully-custom-phone-input) section for a complete example.
 
 ```kotlin
 CountrySelectionDialog(
@@ -76,7 +79,9 @@ CountrySelectionDialog(
     containerColor = MaterialTheme.colorScheme.background,
     contentColor = MaterialTheme.colorScheme.onBackground,
     onDismissRequest = { /* handle dismiss */ },
-    onSelect = { country -> /* handle selection */ },
+    onSelect = { country ->
+        state.setCode(country.code) // updates state.selectedCountry
+    },
 )
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -107,4 +107,4 @@ For platform-specific details (validation engines, default country detection, ru
 
 ## Next Steps
 
-Head over to the [Usage](usage.md) page to learn how to use the country code picker in your app.
+Head over to the [Usage](usage.md) page to learn how to use the country code picker in your app, including how to build a [fully custom phone input](usage.md#fully-custom-phone-input) with your own text field using `CountrySelectionDialog` and `state.selectedCountry`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ A Compose Multiplatform country code picker built with Material 3 for **Android*
 - **Phone number validation & formatting** — powered by libphonenumber on Android/JVM, built-in rules on iOS/JS/WasmJS
 - **Accent-normalized search** — find countries regardless of diacritics
 - **Responsive dialog** — full-screen on compact screens, popup on expanded screens
+- **Custom text field support** — use `CountrySelectionDialog` and `state.selectedCountry` to build fully custom phone inputs with your own design system
 - **15 language translations** — Arabic, German, Spanish, French, Hindi, Indonesian, Italian, Japanese, Marathi, Dutch, Russian, Swahili, Tamil, Turkish, Vietnamese
 - **Fully customizable** — colors, shapes, icons, text styles, and flag sizes
 - **Keyboard navigation** — Arrow keys, Enter, and Escape support on desktop and web

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -62,6 +62,9 @@ The `isPhoneNumberValid()` API is unchanged. The underlying engine differs by pl
 - **Keyboard navigation** — Arrow keys, Enter, and Escape in the country selection dialog
 - **Per-country phone validation and formatting** on all platforms
 - **Improved search** with accent/diacritic normalization
+- **`state.selectedCountry`** — exposes the full `Country` object (flag, name, code, phoneNoCode) so you can build fully custom phone inputs with your own text field
+- **`CountrySelectionDialog` as standalone API** — use it independently with your own text field; pass `state.countryList` for the data and call `state.setCode(country.code)` on selection
+- **`selectedCountryPadding`** — new parameter to control padding around the country selector, useful when embedding inside a custom text field's decorator box
 - **New parameters**: `trailingIcon`, `keyboardOptions`, `keyboardActions`, `enabled`
 
 ## Breaking Changes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,7 @@ TextField(
         KomposeCountryCodePicker(
             modifier = Modifier,
             showOnlyCountryCodePicker = true,
+            selectedCountryPadding = 0.dp, // adjust or remove default padding
             text = phoneNumber,
             state = state,
         )
@@ -76,6 +77,84 @@ TextField(
     ),
 )
 ```
+
+!!! tip
+    Use `selectedCountryPadding` to control the padding around the country selector. The default is `8.dp` on all sides. Set it to `0.dp` when embedding inside a text field's decorator box to avoid extra spacing.
+
+## Fully Custom Phone Input
+
+If your app has its own design system with custom text field components, you likely don't want to use `KomposeCountryCodePicker` at all — it comes with its own `OutlinedTextField` baked in. Instead, you want to use your own text field and only rely on the library for the country data (flags, phone codes) and the searchable country selection dialog.
+
+The `state.selectedCountry` property makes this possible. It exposes the full `Country` object — including the `flag` drawable — so you can render the selected country anywhere in your own layout.
+
+Here is a complete, production-ready example:
+
+```kotlin
+@OptIn(RestrictedApi::class)
+@Composable
+fun PhoneNumberField() {
+    var phoneNumber by rememberSaveable { mutableStateOf("") }
+    var showCountryPicker by rememberSaveable { mutableStateOf(false) }
+    val state = rememberKomposeCountryCodePickerState()
+
+    // 1. Show the country selection dialog when the user taps the country section
+    if (showCountryPicker) {
+        CountrySelectionDialog(
+            countryList = state.countryList,
+            containerColor = MaterialTheme.colorScheme.background,
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            onDismissRequest = { showCountryPicker = false },
+            onSelect = { country ->
+                state.setCode(country.code)
+                showCountryPicker = false
+            },
+        )
+    }
+
+    // 2. Build your own text field — any TextField, OutlinedTextField, or BasicTextField
+    OutlinedTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = phoneNumber,
+        onValueChange = { phoneNumber = it },
+        placeholder = { Text("Phone Number") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+        leadingIcon = {
+            // 3. Use state.selectedCountry to display the flag and phone code
+            Row(
+                modifier = Modifier
+                    .clickable { showCountryPicker = true }
+                    .padding(start = 12.dp, end = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    modifier = Modifier.width(28.dp).height(18.dp),
+                    painter = painterResource(state.selectedCountry.flag),
+                    contentDescription = state.selectedCountry.name,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(text = state.selectedCountry.phoneNoCode)
+            }
+        },
+    )
+
+    // 4. Access phone data from the state as usual
+    val fullNumber = "${state.getCountryPhoneCode()}$phoneNumber"
+}
+```
+
+**What you get from `state.selectedCountry`:**
+
+| Property | Type | Example |
+|---|---|---|
+| `state.selectedCountry.flag` | `DrawableResource` | The country's flag drawable |
+| `state.selectedCountry.name` | `String` | `"Kenya"` |
+| `state.selectedCountry.phoneNoCode` | `String` | `"+254"` |
+| `state.selectedCountry.code` | `String` | `"ke"` |
+
+!!! note
+    `state.setCode()` is annotated with `@RestrictedApi` because it's intended for advanced use cases where you manage the state yourself. Add `@OptIn(RestrictedApi::class)` to your function and import `com.joelkanyi.jcomposecountrycodepicker.annotation.RestrictedApi`.
+
+Check the **Custom** tab in the sample app for more examples, including a `BasicTextField` variant with a fully custom layout.
 
 ## Reading Phone Number Data
 
@@ -93,6 +172,8 @@ Use the `state` object to access all phone number information:
 | `state.getFullPhoneNumberWithoutPrefix()` | Full number without `+` prefix | `254712345678` |
 | `state.getFullyFormattedPhoneNumber()` | Formatted full number | `+254 712 345678` |
 | `state.isPhoneNumberValid()` | Whether the number is valid | `true` / `false` |
+| `state.selectedCountry` | The currently selected `Country` object | `Country(code=ke, ...)` |
+| `state.selectedCountry.flag` | Flag drawable resource of the selected country | `DrawableResource` |
 
 ## Validation Example
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.0"
+agp = "9.1.1"
 kotlin = "2.3.21"
 compose-multipatform = "1.10.3"
 activityCompose = "1.13.0"

--- a/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
@@ -4,8 +4,8 @@ public abstract interface annotation class com/joelkanyi/jcomposecountrycodepick
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt;
 	public fun <init> ()V
-	public final fun getLambda$-797883394$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-887531264$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-415359874$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$354603068$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface class com/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker {
@@ -19,6 +19,7 @@ public abstract interface class com/joelkanyi/jcomposecountrycodepicker/componen
 	public abstract fun getFullyFormattedPhoneNumber ()Ljava/lang/String;
 	public abstract fun getPhoneNumber ()Ljava/lang/String;
 	public abstract fun getPhoneNumberWithoutPrefix ()Ljava/lang/String;
+	public abstract fun getSelectedCountry ()Lcom/joelkanyi/jcomposecountrycodepicker/data/Country;
 	public abstract fun getShowCountryCode ()Z
 	public abstract fun getShowCountryFlag ()Z
 	public abstract fun isPhoneNumberValid (Ljava/lang/String;)Z
@@ -36,7 +37,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySele
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
-	public static final fun KomposeCountryCodePicker-3lkZ96c (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun KomposeCountryCodePicker-9udWUoQ (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;FLandroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
 	public static final fun SelectedCountryComponent-VG7Fs9s (Lcom/joelkanyi/jcomposecountrycodepicker/data/Country;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;FZZZJLandroidx/compose/runtime/Composer;III)V
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -104,6 +104,9 @@ public interface CountryCodePicker {
      */
     public val countryList: List<Country>
 
+    /** Returns the currently selected [Country]. */
+    public val selectedCountry: Country
+
     /** Returns the country name. i.e Kenya. */
     public fun getCountryName(): String
 
@@ -215,6 +218,9 @@ internal class CountryCodePickerImpl(
     )
     override val countryList: List<Country>
         get() = _countryList.value
+
+    override val selectedCountry: Country
+        get() = countryCode.getCountry()
 
     override fun getCountryName(): String = countryCode.getCountry().name.replaceFirstChar {
         it.uppercase()
@@ -372,6 +378,8 @@ public fun rememberKomposeCountryCodePickerState(
  * @param enabled Controls the enabled state of the text field.
  * @param keyboardOptions The keyboard options to be used for the
  *    text field.
+ * @param selectedCountryPadding The padding around the selected country
+ *    component. Defaults to 8.dp.
  * @param keyboardActions The keyboard actions to be used for the
  *    text field.
  */
@@ -431,6 +439,7 @@ public fun KomposeCountryCodePicker(
         keyboardType = KeyboardType.Phone,
         imeAction = ImeAction.Next,
     ),
+    selectedCountryPadding: Dp = 8.dp,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
     var openCountrySelectionDialog by rememberSaveable { mutableStateOf(false) }
@@ -477,6 +486,7 @@ public fun KomposeCountryCodePicker(
                 }
             },
             selectedCountryFlagSize = selectedCountryFlagSize,
+            selectedCountryPadding = selectedCountryPadding,
             textStyle = textStyle,
             dropDownIcon = dropDownIcon,
             containerColor = leadingIconContainerColor,
@@ -552,6 +562,7 @@ public fun KomposeCountryCodePicker(
                         }
                     },
                     selectedCountryFlagSize = selectedCountryFlagSize,
+                    selectedCountryPadding = selectedCountryPadding,
                     textStyle = textStyle,
                     dropDownIcon = dropDownIcon,
                 )

--- a/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/fake/FakeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/commonTest/kotlin/com/joelkanyi/jcomposecountrycodepicker/fake/FakeCountryCodePicker.kt
@@ -29,6 +29,9 @@ class FakeCountryCodePicker(
     override var countryList: List<Country> = countries
     override val showCountryCode: Boolean = true
     override val showCountryFlag: Boolean = true
+    override val selectedCountry: Country
+        get() = countryList.firstOrNull { it.code.equals(countryCode, ignoreCase = true) }
+            ?: countryList.first()
 
     override fun getCountryName(): String = countryList.first().name
 

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
             api(compose.ui)
             api(compose.foundation)
             api(compose.material3)
+            implementation(compose.components.resources)
             implementation(project(":komposecountrycodepicker"))
         }
     }

--- a/sample/shared/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/sample/CustomTextFieldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/sample/CustomTextFieldSample.kt
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2025 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.joelkanyi.jcomposecountrycodepicker.sample
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.joelkanyi.jcomposecountrycodepicker.annotation.RestrictedApi
+import com.joelkanyi.jcomposecountrycodepicker.component.CountrySelectionDialog
+import com.joelkanyi.jcomposecountrycodepicker.component.rememberKomposeCountryCodePickerState
+import org.jetbrains.compose.resources.painterResource
+
+@OptIn(RestrictedApi::class)
+@Composable
+internal fun CustomTextFieldSample() {
+    var phoneNumber by rememberSaveable { mutableStateOf("") }
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+    val state = rememberKomposeCountryCodePickerState(
+        showCountryCode = true,
+        showCountryFlag = true,
+    )
+
+    if (showDialog) {
+        CountrySelectionDialog(
+            countryList = state.countryList,
+            containerColor = MaterialTheme.colorScheme.background,
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            onDismissRequest = { showDialog = false },
+            onSelect = { country ->
+                state.setCode(country.code)
+                showDialog = false
+            },
+        )
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .widthIn(max = 480.dp)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        contentPadding = PaddingValues(vertical = 24.dp),
+    ) {
+        item {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = "Build your own phone input using CountrySelectionDialog " +
+                    "and state.selectedCountry — no KomposeCountryCodePicker needed.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // -- Example 1: OutlinedTextField with country picker leading icon --
+        item {
+            SectionHeader(
+                title = "With OutlinedTextField",
+                subtitle = "Your own OutlinedTextField with the flag and phone code as a leading icon",
+            )
+        }
+
+        item {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = phoneNumber,
+                onValueChange = { phoneNumber = it },
+                placeholder = {
+                    Text(
+                        text = "Phone Number",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                colors = OutlinedTextFieldDefaults.colors(
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                ),
+                leadingIcon = {
+                    Row(
+                        modifier = Modifier
+                            .clickable(
+                                interactionSource = MutableInteractionSource(),
+                                indication = null,
+                            ) { showDialog = true }
+                            .padding(start = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Image(
+                            modifier = Modifier
+                                .size(width = 28.dp, height = 18.dp)
+                                .clip(RoundedCornerShape(2.dp)),
+                            painter = painterResource(state.selectedCountry.flag),
+                            contentDescription = state.selectedCountry.name,
+                        )
+
+                        Spacer(modifier = Modifier.width(6.dp))
+
+                        Text(
+                            text = state.selectedCountry.phoneNoCode,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+
+                        Spacer(modifier = Modifier.width(4.dp))
+
+                        // Dropdown chevron
+                        Text(
+                            text = "\u25BE",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                        Spacer(modifier = Modifier.width(10.dp))
+
+                        // Vertical separator
+                        Box(
+                            modifier = Modifier
+                                .width(1.dp)
+                                .height(24.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.outlineVariant,
+                                ),
+                        )
+                    }
+                },
+            )
+        }
+
+        // -- Example 2: BasicTextField with custom styling --
+        item {
+            SectionHeader(
+                title = "With BasicTextField",
+                subtitle = "Fully custom design — your own borders, background, and layout",
+            )
+        }
+
+        item {
+            BasicTextFieldWithCountryPicker(
+                phoneNumber = phoneNumber,
+                onPhoneNumberChange = { phoneNumber = it },
+                flag = {
+                    Image(
+                        modifier = Modifier
+                            .size(width = 28.dp, height = 18.dp)
+                            .clip(RoundedCornerShape(2.dp)),
+                        painter = painterResource(state.selectedCountry.flag),
+                        contentDescription = state.selectedCountry.name,
+                    )
+                },
+                countryCode = state.selectedCountry.phoneNoCode,
+                onCountryClick = { showDialog = true },
+            )
+        }
+
+        // -- Selected Country Info --
+        item {
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+        }
+
+        item {
+            SectionHeader(
+                title = "state.selectedCountry",
+                subtitle = "All the data you get from the selected country — flag, name, code, and phone code",
+            )
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                ),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Image(
+                            modifier = Modifier
+                                .size(width = 40.dp, height = 26.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                            painter = painterResource(state.selectedCountry.flag),
+                            contentDescription = state.selectedCountry.name,
+                        )
+                        Column {
+                            Text(
+                                text = state.selectedCountry.name,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                ),
+                            )
+                            Text(
+                                text = "${state.selectedCountry.phoneNoCode} (${state.selectedCountry.code.uppercase()})",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+                    DetailRow(label = "Country Code", value = state.selectedCountry.code.uppercase())
+                    DetailRow(label = "Phone Code", value = state.selectedCountry.phoneNoCode)
+                    DetailRow(label = "Country Name", value = state.selectedCountry.name)
+                    if (phoneNumber.isNotBlank()) {
+                        DetailRow(
+                            label = "Full Number",
+                            value = "${state.getCountryPhoneCode()}$phoneNumber",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    title: String,
+    subtitle: String,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+            ),
+        )
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun BasicTextFieldWithCountryPicker(
+    phoneNumber: String,
+    onPhoneNumberChange: (String) -> Unit,
+    flag: @Composable () -> Unit,
+    countryCode: String,
+    onCountryClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .clip(RoundedCornerShape(12.dp)),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Country selector section
+        Row(
+            modifier = Modifier
+                .clickable(
+                    interactionSource = MutableInteractionSource(),
+                    indication = null,
+                ) { onCountryClick() }
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                .padding(horizontal = 12.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            flag()
+
+            Text(
+                text = countryCode,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = FontWeight.Medium,
+                ),
+            )
+
+            Text(
+                text = "\u25BE",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // Vertical separator
+        Box(
+            modifier = Modifier
+                .width(1.dp)
+                .height(32.dp)
+                .background(MaterialTheme.colorScheme.outlineVariant),
+        )
+
+        // Phone number input
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 12.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            if (phoneNumber.isEmpty()) {
+                Text(
+                    text = "Phone Number",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                )
+            }
+            BasicTextField(
+                value = phoneNumber,
+                onValueChange = onPhoneNumberChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+            ),
+        )
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/sample/Sample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/sample/Sample.kt
@@ -66,6 +66,11 @@ fun Sample(modifier: Modifier = Modifier) {
                     onClick = { selectedTab = 1 },
                     text = { Text("Login") },
                 )
+                Tab(
+                    selected = selectedTab == 2,
+                    onClick = { selectedTab = 2 },
+                    text = { Text("Custom") },
+                )
             }
         },
     ) { paddingValues ->
@@ -78,6 +83,7 @@ fun Sample(modifier: Modifier = Modifier) {
             when (selectedTab) {
                 0 -> PickerSample()
                 1 -> LoginSample()
+                2 -> CustomTextFieldSample()
             }
         }
     }


### PR DESCRIPTION
* Expose `selectedCountry` in `CountryCodePicker` state to allow access to the selected country's flag, name, and code.
* Introduce `selectedCountryPadding` parameter to `KomposeCountryCodePicker` for better layout control in custom containers.
* Update `CountrySelectionDialog` documentation to highlight its use as a standalone component for custom UI implementations.
* Add a comprehensive "Custom" sample demonstrating `BasicTextField` and `OutlinedTextField` integration.
* Downgrade `com.android.application` (AGP) from 9.2.0 to 9.1.1.