### PR TITLE
add `countryCodeTextStyle` to `KomposeCountryCodePicker`

### DIFF
--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -46,7 +46,8 @@ The `KomposeCountryCodePicker` composable accepts the following parameters:
 | `leadingIconContainerColor` | `Color` | `Color.Unspecified` | Background color of the country selector area. When `Color.Unspecified`, no background is drawn. |
 | `interactionSource` | `MutableInteractionSource` | `MutableInteractionSource()` | The interaction source for the text field. |
 | `selectedCountryFlagSize` | `FlagSize` | `FlagSize(28.dp, 18.dp)` | The width and height of the selected country flag. |
-| `textStyle` | `TextStyle` | `LocalTextStyle.current` | The text style for the text field and selected country display. |
+| `textStyle` | `TextStyle` | `LocalTextStyle.current` | The text style for the phone number text field. Also used for the country code when `countryCodeTextStyle` is not set. |
+| `countryCodeTextStyle` | `TextStyle?` | `null` | The text style for the country code text (e.g. "+254"). When `null`, falls back to `textStyle`. |
 | `enabled` | `Boolean` | `true` | Whether the text field and country picker are enabled. |
 | `keyboardOptions` | `KeyboardOptions` | Phone / Next | Keyboard options for the text field. Defaults to phone keyboard with `ImeAction.Next`. |
 | `selectedCountryPadding` | `Dp` | `8.dp` | Padding around the selected country component. Useful for removing extra spacing when embedding the picker inside a custom text field's decorator box. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,6 +34,24 @@ KomposeCountryCodePicker(
 
 The `state` object holds all the phone number data. Use `text` to provide the current input and `onValueChange` to update it — the same controlled-text pattern used by standard Compose text fields.
 
+### Independent Text Styles
+
+By default, `textStyle` applies to both the phone number input and the country code. To style them independently, use `countryCodeTextStyle`:
+
+```kotlin
+KomposeCountryCodePicker(
+    modifier = Modifier.fillMaxWidth(),
+    text = phoneNumber,
+    onValueChange = { phoneNumber = it },
+    state = state,
+    textStyle = MaterialTheme.typography.bodyLarge, // phone number input
+    countryCodeTextStyle = MaterialTheme.typography.labelMedium.copy(
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.primary,
+    ), // country code only
+)
+```
+
 ## Country Code Picker Only
 
 Set `showOnlyCountryCodePicker = true` to display just the country selector without a text field. This is useful when embedding the picker into a custom layout.

--- a/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/jvm/komposecountrycodepicker.api
@@ -4,8 +4,8 @@ public abstract interface annotation class com/joelkanyi/jcomposecountrycodepick
 public final class com/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt {
 	public static final field INSTANCE Lcom/joelkanyi/jcomposecountrycodepicker/component/ComposableSingletons$KomposeCountryCodePickerKt;
 	public fun <init> ()V
-	public final fun getLambda$-415359874$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$354603068$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-735772604$komposecountrycodepicker ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1216832006$komposecountrycodepicker ()Lkotlin/jvm/functions/Function2;
 }
 
 public abstract interface class com/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker {
@@ -37,7 +37,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/CountrySele
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
-	public static final fun KomposeCountryCodePicker-9udWUoQ (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;FLandroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun KomposeCountryCodePicker-rwElUJM (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;FLandroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;IIII)V
 	public static final fun SelectedCountryComponent-VG7Fs9s (Lcom/joelkanyi/jcomposecountrycodepicker/data/Country;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;FZZZJLandroidx/compose/runtime/Composer;III)V
 	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }

--- a/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/commonMain/kotlin/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -374,7 +374,11 @@ public fun rememberKomposeCountryCodePickerState(
  * @param selectedCountryFlagSize The size of the selected country flag
  *    (width and height in [Dp][androidx.compose.ui.unit.Dp]).
  * @param textStyle The style to be used for displaying text on the
- *    `TextField` and the selected country.
+ *    `TextField` and the selected country (when [countryCodeTextStyle]
+ *    is not set).
+ * @param countryCodeTextStyle The style to be used for the country code
+ *    text inside the selected country component. When `null`, falls back
+ *    to [textStyle].
  * @param enabled Controls the enabled state of the text field.
  * @param keyboardOptions The keyboard options to be used for the
  *    text field.
@@ -434,6 +438,7 @@ public fun KomposeCountryCodePicker(
     interactionSource: MutableInteractionSource = MutableInteractionSource(),
     selectedCountryFlagSize: FlagSize = FlagSize(28.dp, 18.dp),
     textStyle: TextStyle = LocalTextStyle.current,
+    countryCodeTextStyle: TextStyle? = null,
     enabled: Boolean = true,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default.copy(
         keyboardType = KeyboardType.Phone,
@@ -442,6 +447,8 @@ public fun KomposeCountryCodePicker(
     selectedCountryPadding: Dp = 8.dp,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
+    val resolvedCountryCodeTextStyle = countryCodeTextStyle ?: textStyle
+
     var openCountrySelectionDialog by rememberSaveable { mutableStateOf(false) }
 
     val phoneTextPair = extractCountryCodeAndPhoneNumber(text)
@@ -487,7 +494,7 @@ public fun KomposeCountryCodePicker(
             },
             selectedCountryFlagSize = selectedCountryFlagSize,
             selectedCountryPadding = selectedCountryPadding,
-            textStyle = textStyle,
+            textStyle = resolvedCountryCodeTextStyle,
             dropDownIcon = dropDownIcon,
             containerColor = leadingIconContainerColor,
         )
@@ -563,7 +570,7 @@ public fun KomposeCountryCodePicker(
                     },
                     selectedCountryFlagSize = selectedCountryFlagSize,
                     selectedCountryPadding = selectedCountryPadding,
-                    textStyle = textStyle,
+                    textStyle = resolvedCountryCodeTextStyle,
                     dropDownIcon = dropDownIcon,
                 )
             },


### PR DESCRIPTION
Allows independent styling of the country code and the phone number input field. When `countryCodeTextStyle` is not provided, it falls back to the default `textStyle`.

* Added `countryCodeTextStyle` parameter to `KomposeCountryCodePicker`.
* Updated documentation in `usage.md` and `customizations.md` to reflect the new styling option.
* Updated JVM API surface definitions.

this fixes #248